### PR TITLE
Initialize CAP database

### DIFF
--- a/backend/routes/main.js
+++ b/backend/routes/main.js
@@ -7,11 +7,11 @@ const protector = require('../utils/keycloak_utils').protector;
 /* Getters Area. */
 router.get("/", (req, res, next) => {
     console.log(req);
-    res.status(200).send(JSON.stringify({message: res}));
+    res.status(200).send(JSON.stringify({response: "Server is responding to the root url."}));
 });
 
 router.get("/protect", keycloak.protect(protector), (req, res, next) => {
-    res.status(200).send(JSON.stringify({response: "Server is responding to the root url."}));
+    res.status(200).send(JSON.stringify({response: "Protected endpoint"}));
 });
 
 router.get('/logout', keycloak.protect(), (req, res, next)=>{
@@ -33,6 +33,7 @@ router.get('/gettoken', (req, res, next)=>{
             let access_token = grant.access_token.token;
             let refresh_token = grant.refresh_token.token;
             console.log("Access Token: ", access_token);
+            console.log("Refresh Token: ", refresh_token);
             console.log(grant);
             keycloak.storeGrant(grant, req, res);
             console.log("stored grant")

--- a/cleanDB/Dockerfile
+++ b/cleanDB/Dockerfile
@@ -4,7 +4,7 @@
 # dump build stage
 FROM postgres:11-alpine as dumper
 
-COPY ./scripts/* /docker-entrypoint-initdb.d/
+COPY /scripts/ /docker-entrypoint-initdb.d/
 
 RUN ["sed", "-i", "s/exec \"$@\"/echo \"skipping...\"/", "/usr/local/bin/docker-entrypoint.sh"]
 

--- a/cleanDB/Dockerfile
+++ b/cleanDB/Dockerfile
@@ -18,3 +18,5 @@ RUN ["/usr/local/bin/docker-entrypoint.sh", "postgres"]
 FROM postgres:11-alpine
 
 COPY --from=dumper /data $PGDATA
+
+COPY /conf/pg_hba.conf /var/lib/postgresql/data/pg_hba.conf

--- a/cleanDB/conf/pg_hba.conf
+++ b/cleanDB/conf/pg_hba.conf
@@ -1,0 +1,16 @@
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     password
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            password
+# IPv6 local connections:
+host    all             all             ::1/128                 password
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     password
+host    replication     all             127.0.0.1/32            password
+host    replication     all             ::1/128                 password
+
+# All other connetions require encypted password
+host    all             all             all                     md5

--- a/cleanDB/scripts/clean_db.sql
+++ b/cleanDB/scripts/clean_db.sql
@@ -1,0 +1,142 @@
+-- More info at https://cadu.dev/creating-a-docker-image-with-database-preloaded/
+
+-- Dumped from database version 11.5
+-- Dumped by pg_dump version 11.3
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: clean_db; Type: DATABASE; Schema: -; Owner: postgres
+--
+
+-- Creating the CAP database
+CREATE DATABASE clean_db WITH TEMPLATE = template0 ENCODING = 'UTF8' LC_COLLATE = 'en_US.utf8' LC_CTYPE = 'en_US.utf8';
+ALTER DATABASE clean_db OWNER TO postgres;
+
+\connect clean_db
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+
+\connect clean_db
+
+--
+-- Name: students; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.students (
+    id       CHAR(6)    NOT NULL,
+    group_id INT        NOT NULL,
+    PRIMARY KEY(id)
+);
+
+
+ALTER TABLE public.students OWNER TO postgres;
+
+--
+-- Name: sections; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sections (
+    id         CHAR(50)    NOT NULL,
+    group_id   INT         NOT NULL,
+    PRIMARY KEY (id, group_id)
+);
+
+
+ALTER TABLE public.sections OWNER TO postgres;
+
+--
+-- Name: tasks; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.tasks (
+    id      CHAR(50)    NOT NULL,
+    section CHAR(50)    NOT NULL,
+    max     INT         NOT NULL,
+    PRIMARY KEY (id, section)
+);
+
+
+ALTER TABLE public.tasks OWNER TO postgres;
+
+--
+-- Name: grades; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.grades (
+    student_id  CHAR(6)     REFERENCES  students(id) NOT NULL,
+    task_id     CHAR(50)    NOT NULL,
+    grade       INT         NOT NULL,
+    PRIMARY KEY (student_id, task_id)
+);
+
+
+ALTER TABLE public.grades OWNER TO postgres;
+
+--
+-- Name: teachers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.teachers (
+    id          CHAR(6)     REFERENCES students(id) NOT NULL,
+    group_id    INT         NOT NULL,
+    PRIMARY KEY (id, group_id)
+);
+
+
+ALTER TABLE public.teachers OWNER TO postgres;
+
+
+-- Filling the tables with dummy values
+
+INSERT INTO students VALUES ('81AMIA', 1);
+INSERT INTO students VALUES ('9YV5TX', 1);
+INSERT INTO students VALUES ('ZEADKD', 2);
+INSERT INTO students VALUES ('B8WNS6', 3);
+INSERT INTO students VALUES ('NM82SK', 4);
+
+INSERT INTO sections VALUES ('Homework', 1);
+INSERT INTO sections VALUES ('Progress Task', 1);
+INSERT INTO sections VALUES ('Homework', 2);
+INSERT INTO sections VALUES ('Midterm', 3);
+INSERT INTO sections VALUES ('Endterm', 4);
+
+INSERT INTO tasks VALUES ('Homework 1', 'Homework', 1);
+INSERT INTO tasks VALUES ('Progress Task 1', 'Progress Task', 1);
+INSERT INTO tasks VALUES ('Homework 2', 'Homework', 2);
+INSERT INTO tasks VALUES ('Midterm', 'Midterm', 3);
+INSERT INTO tasks VALUES ('Endterm', 'Endterm', 4);
+
+INSERT INTO grades VALUES ('81AMIA', 'Homework 1', 5);
+INSERT INTO grades VALUES ('9YV5TX', 'Homework 1', 2);
+INSERT INTO grades VALUES ('9YV5TX', 'Midterm', 3);
+INSERT INTO grades VALUES ('ZEADKD', 'Midterm', 3);
+INSERT INTO grades VALUES ('ZEADKD', 'Endterm', 4);
+
+INSERT INTO teachers VALUES ('B8WNS6', 1);
+INSERT INTO teachers VALUES ('B8WNS6', 2);
+INSERT INTO teachers VALUES ('NM82SK', 3);
+INSERT INTO teachers VALUES ('NM82SK', 4);

--- a/cleanDB/scripts/init.sql
+++ b/cleanDB/scripts/init.sql
@@ -18,15 +18,12 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: test_db; Type: DATABASE; Schema: -; Owner: postgres
+-- Name: clean_db; Type: DATABASE; Schema: -; Owner: postgres
 --
 
-
--- Creating some random database
-CREATE DATABASE test_db WITH TEMPLATE = template0 ENCODING = 'UTF8' LC_COLLATE = 'en_US.utf8' LC_CTYPE = 'en_US.utf8';
-ALTER DATABASE test_db OWNER TO postgres;
-
-\connect test_db
+-- Creating the CAP database
+CREATE DATABASE clean_db WITH TEMPLATE = template0 ENCODING = 'UTF8' LC_COLLATE = 'en_US.utf8' LC_CTYPE = 'en_US.utf8';
+ALTER DATABASE clean_db OWNER TO postgres;
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -43,63 +40,105 @@ SET default_tablespace = '';
 
 SET default_with_oids = false;
 
+\connect clean_db
+
 --
--- Name: clients; Type: TABLE; Schema: public; Owner: postgres
+-- Name: students; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.clients (
-    id integer NOT NULL,
-    name character varying(150) NOT NULL
+CREATE TABLE public.students (
+    id       CHAR(6)    NOT NULL,
+    group_id INT        NOT NULL,
+    PRIMARY KEY(id)
 );
 
 
-ALTER TABLE public.clients OWNER TO postgres;
+ALTER TABLE public.students OWNER TO postgres;
 
 --
--- Name: clients_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: sections; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE SEQUENCE public.clients_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+CREATE TABLE public.sections (
+    id         CHAR(50)    NOT NULL,
+    group_id   INT         NOT NULL,
+    PRIMARY KEY (id, group_id)
+);
 
 
-ALTER TABLE public.clients_id_seq OWNER TO postgres;
---
--- Name: clients_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
---
-ALTER SEQUENCE public.clients_id_seq OWNED BY public.clients.id;
-
+ALTER TABLE public.sections OWNER TO postgres;
 
 --
--- Name: clients id; Type: DEFAULT; Schema: public; Owner: postgres
---
-ALTER TABLE ONLY public.clients ALTER COLUMN id SET DEFAULT nextval('public.clients_id_seq'::regclass);
-
-
---
--- Data for Name: clients; Type: TABLE DATA; Schema: public; Owner: postgres
+-- Name: tasks; Type: TABLE; Schema: public; Owner: postgres
 --
 
-COPY public.clients (id, name) FROM stdin;
-1	Client 1
-2	Client 2
-\.
+CREATE TABLE public.tasks (
+    id      CHAR(50)    NOT NULL,
+    section CHAR(50)    NOT NULL,
+    max     INT         NOT NULL,
+    PRIMARY KEY (id, section)
+);
 
 
---
--- Name: clients_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
---
-SELECT pg_catalog.setval('public.clients_id_seq', 2, true);
-
+ALTER TABLE public.tasks OWNER TO postgres;
 
 --
--- Name: clients clients_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: grades; Type: TABLE; Schema: public; Owner: postgres
 --
-ALTER TABLE ONLY public.clients
-    ADD CONSTRAINT clients_pkey PRIMARY KEY (id);
 
+select * from students;
+
+CREATE TABLE public.grades (
+    student_id  CHAR(6)     REFERENCES  students(id) NOT NULL,
+    task_id     CHAR(50)    NOT NULL,
+    grade       INT         NOT NULL,
+    PRIMARY KEY (student_id, task_id)
+);
+
+
+ALTER TABLE public.grades OWNER TO postgres;
+
+--
+-- Name: teachers; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.teachers (
+    id          CHAR(6)     REFERENCES students(id) NOT NULL,
+    group_id    INT         NOT NULL,
+    PRIMARY KEY (id, group_id)
+);
+
+
+ALTER TABLE public.teachers OWNER TO postgres;
+
+
+-- Filling the tables with dummy values
+
+INSERT INTO students VALUES ('81AMIA', 1);
+INSERT INTO students VALUES ('9YV5TX', 1);
+INSERT INTO students VALUES ('ZEADKD', 2);
+INSERT INTO students VALUES ('B8WNS6', 3);
+INSERT INTO students VALUES ('NM82SK', 4);
+
+INSERT INTO sections VALUES ('Homework', 1);
+INSERT INTO sections VALUES ('Progress Task', 1);
+INSERT INTO sections VALUES ('Homework', 2);
+INSERT INTO sections VALUES ('Midterm', 3);
+INSERT INTO sections VALUES ('Endterm', 4);
+
+INSERT INTO tasks VALUES ('Homework 1', 'Homework', 1);
+INSERT INTO tasks VALUES ('Progress Task 1', 'Progress Task', 1);
+INSERT INTO tasks VALUES ('Homework 2', 'Homework', 2);
+INSERT INTO tasks VALUES ('Midterm', 'Midterm', 3);
+INSERT INTO tasks VALUES ('Endterm', 'Endterm', 4);
+
+INSERT INTO grades VALUES ('81AMIA', 'Homework 1', 5);
+INSERT INTO grades VALUES ('9YV5TX', 'Homework 1', 2);
+INSERT INTO grades VALUES ('9YV5TX', 'Midterm', 3);
+INSERT INTO grades VALUES ('ZEADKD', 'Midterm', 3);
+INSERT INTO grades VALUES ('ZEADKD', 'Endterm', 4);
+
+INSERT INTO teachers VALUES ('B8WNS6', 1);
+INSERT INTO teachers VALUES ('B8WNS6', 2);
+INSERT INTO teachers VALUES ('NM82SK', 3);
+INSERT INTO teachers VALUES ('NM82SK', 4);

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,12 +1,6 @@
 version: '3.3'
 
 services:   
-    # cleanplatform:
-        # image : 
-        # command : 
-        # ports:
-        # env_file:
-
     nginx:
         image: nginx:latest
         ports:
@@ -57,7 +51,7 @@ services:
     cleanDB:
         image: cleandb:latest # This image is preloaded with the data we need. Setting up shared volumes or copying the data with dockercompose volumes had problems
         ports:
-            - 5003:5432
+            - 5432:5432
         env_file:
             - cleanDB/env/postgres.env
         

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "npm run sass-dev & next dev",
-    "build": "next build",
+    "build": "npm run sass-prod && next build",
     "start": "next start",
     "prod": "npm run build && next start -p 80",
     "lint": "next lint",

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,10 +10,10 @@ http {
         server_name     localhost 127.0.0.1;
         listen          80;
 
-        # location / {
-        #     proxy_set_header    Host                    $http_host;
-        #     proxy_pass          http://frontend/;
-        # }
+        location / {
+            proxy_set_header    Host                    $http_host;
+            proxy_pass          http://frontend/;
+        }
 
         location /api/v1/ {
             proxy_set_header    Host                    $http_host;

--- a/platform_build_deploy.sh
+++ b/platform_build_deploy.sh
@@ -33,7 +33,7 @@ then
 
     echo "----------------------------------------------------------------------------------- ";
 
-    # Building the clean database
+    # Building the frontend
     echo "Building the react frontend...";
     cd frontend;
     docker build . -t frontend:latest;


### PR DESCRIPTION
Initialized the CAP database according to our design in #18 

The database is built within the cleanDB image which also holds the keycloak database. I have created the clean_db database and it holds the students, teachers, sections, tasks, and grades tables. At this stage I have filled the tables with dummy information for further development and debugging purposes. You can view the tables either through the pgadmin web UI or by accessing the cleanDB container directly. 

Here are the commands needed to get to the tables in the container:
```
docker exec -it clean-administration-platform_cleanDB_1 bin/sh
psql -U postgres
(enter password "postgres" when prompted)
\c clean_db
```
From here execute ```\dt``` to see a table of all tables and ```select * from <table_name>;``` to see a table's contents.

UPDATE:
Created keycloaker and demonstrator roles which only have access to auth_db and clean_db respectively. They have full privileges within their databases. Now made it so that the database trusts no connections and always prompts for passwords. Currently the password for keycloaker is "password1" and for demonstrator it is "password2".
Example:
```
psql -U keycloaker -d auth_db
psql -U demonstrator -d clean_db
```