### PR TITLE
User Profile Endpoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "keycloak-connect": "^17.0.0",
     "pg": "^8.7.3",
     "qs": "^6.9.4",
+    "axios": "^0.26.1",
     "querystring": "^0.2.0"
   },
   "devDependencies": {

--- a/backend/routes/main.js
+++ b/backend/routes/main.js
@@ -11,6 +11,13 @@ const startTrans = require('../utils/database_utils').startTrans;
 const endTrans = require('../utils/database_utils').endTrans;
 const log = require('../utils/logger_utils').log;
 
+/* Importing Routers */
+const usersRouter = require('./users');
+
+
+router.use('/users', usersRouter);
+
+
 // --------------------------------------- Main Endpoint ---------------------------------------
 
 /**

--- a/backend/routes/main.js
+++ b/backend/routes/main.js
@@ -107,6 +107,8 @@ router.get("/select/:table", (req, res, next) => {
     qryText += ";"
 
     const qry = { text: qryText };
+    log("DEBUG", qryText);
+
     execQuery(qry)
     .then((result) => res.status(200).send(JSON.stringify({message: result.result.rows})))
     .catch((error) => {console.log(error); return next(error)});;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,0 +1,39 @@
+/** Handles the users functionalities /users/.... */
+
+/* Dependencies Importing */
+const router = require('express-promise-router')();     // Used to handle async request. Will be useful in the future to dodge the pyramid of doom
+const keycloak = require('../utils/keycloak_utils').keycloak;
+const isAuth = require('../utils/keycloak_utils').isAuth;
+const isUnauth = require('../utils/keycloak_utils').isUnauth;
+const {execTrans, startTrans, execQuery, endTrans} = require('../utils/database_utils');
+const log = require('../utils/logger_utils').log;
+const execReq = require('../utils/http_utils').execReq;
+
+/* Getters */
+router.get('/get/profile', keycloak.protect, async (req, res, next) => {
+    keycloak.getGrant(req, res).then((grant) => {
+        const at = grant.access_token;
+        const rt = grant.refresh_token;
+        
+        keycloak.grantManager.userInfo(at)
+         .then((user) => {console.log(user)})
+         .catch((err) => {log("ERROR", "Grant Manager Can't identify the given token."); return next(err);});
+
+        // Get user details from keycloak.
+        //let reqRes = await execReq("GET", "     " ,  );
+
+        // Get user profile from the database.
+       // const qry = { text: "SELECT * FROM `users` WHERE " };
+        //execQuery(qry)
+        //.then((result) => res.status(200).send(JSON.stringify({message: result.result.rows})))
+        //.catch((error) => {console.log(error); return next(error)});
+        res.status(200).send(JSON.stringify({message: "User is logged in and authenticated!"}));
+    }).catch( err => {
+        console.log(err);
+        return next("User must be authenticated to access this page.");
+    });
+});
+
+
+module.exports = router;
+

--- a/backend/utils/http_utils.ts
+++ b/backend/utils/http_utils.ts
@@ -1,0 +1,35 @@
+/** This module handles the utilities of fetching data with http. */
+import axios from "axios";
+import {Method} from "axios";
+
+
+interface RequestResult {
+    result: null | undefined | any, // The result of the request
+    error: null | undefined | any   // The error if any are found
+}
+
+
+/**
+ * Encapsulates our http fetching method. call execReq whenever you want to execute an HTTP request using the
+ *  axios package.
+ * @param method - The method you want to use e.g: "POST", "GET"
+ * @param url - The URL of the request
+ * @param body - The body of the request. Referred to as Data as well
+ * @param headers - The headers of the request.
+ * @returns - an object which either holds the requested result from the url or an error.
+ */
+export async function execReq(method : string , url : string, body : any, headers : any | Record< string, string | number | boolean>) : Promise<RequestResult>{
+    let ret : RequestResult = {} as RequestResult;
+    try {
+        ret.result = await axios({ 
+            method : method as Method,
+            url: url, 
+            data: body,
+            headers: headers
+        });
+        ret.error = null;
+        return ret as RequestResult;
+    }catch(error){
+        return {error: error, result: null} as RequestResult;
+    }
+};

--- a/backend/utils/logger_utils.ts
+++ b/backend/utils/logger_utils.ts
@@ -13,7 +13,7 @@ const LEVELS_TO_NUMBERS = new Map<string, number>([
 ])
 
 /* The maximum log level to show. */
-const MAX_LOG_LEVEL_NUMBER : number = LEVELS_TO_NUMBERS.get(process.env.LOG_LEVEL || 'INFO') || 2;
+const MAX_LOG_LEVEL_NUMBER : number = LEVELS_TO_NUMBERS.get(process.env.LOG_LEVEL || 'DEBUG') || 3;
 
 
 /**
@@ -24,7 +24,7 @@ const MAX_LOG_LEVEL_NUMBER : number = LEVELS_TO_NUMBERS.get(process.env.LOG_LEVE
 export function log(level: string, message: string) : void {
     if(!LEVELS_TO_NUMBERS.has(level))
         throw new Error("No such log level exists!");
-    const log_num = (LEVELS_TO_NUMBERS.get(level) || 2);
+    const log_num = (LEVELS_TO_NUMBERS.get(level) || 3);
     if(MAX_LOG_LEVEL_NUMBER < log_num)
         return;
 

--- a/cleanDB/scripts/clean_db.sql
+++ b/cleanDB/scripts/clean_db.sql
@@ -51,7 +51,6 @@ CREATE TABLE public.users (
     firstname   CHAR(20)    NOT NULL,
     lastname    CHAR(20)    NOT NULL,
     username    CHAR(20)    NOT NULL UNIQUE,
-    keycloak_id CHAR(30),   -- Keycloak id 
     PRIMARY KEY(id)
 );
 
@@ -127,9 +126,9 @@ ALTER TABLE public.user_to_group OWNER TO postgres;
 
 -- Filling the tables with dummy values
 
-INSERT INTO users VALUES ('81AMIA', 'Judita', 'Fenne', 'Ace');
+INSERT INTO users VALUES ('81AMIA', 'Judita', 'Fenne', 'student-1');
 INSERT INTO users VALUES ('9YV5TX', 'Hannah', 'Lochana', 'HannaLocha');
-INSERT INTO users VALUES ('ZEADKD', 'Edan', 'Bahadur', 'Noori');
+INSERT INTO users VALUES ('ZEADKD', 'Edan', 'Bahadur', 'demonstrator-1');
 INSERT INTO users VALUES ('Q50YI1', 'Dita', 'Bertók', 'Queen');
 INSERT INTO users VALUES ('B8WNS6', 'Georg','Vijay', 'Muscleman');
 INSERT INTO users VALUES ('NM82SK', 'Chaz', 'Saundra', 'Picasso');

--- a/cleanDB/scripts/clean_db.sql
+++ b/cleanDB/scripts/clean_db.sql
@@ -51,6 +51,7 @@ CREATE TABLE public.users (
     firstname   CHAR(20)    NOT NULL,
     lastname    CHAR(20)    NOT NULL,
     username    CHAR(20)    NOT NULL UNIQUE,
+    keycloak_id CHAR(30),   -- Keycloak id 
     PRIMARY KEY(id)
 );
 

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -24,6 +24,8 @@ const Login: NextPage = ({ d }) => {
     e.preventDefault();
     fetch("http://localhost:5000/login", {
       method: "POST",
+      mode : "cors",            // Allows the browser to include the headers and tokens in the request
+      credentials : "include", // Allows the browser to send requests to other domains
       headers: {
         "Content-Type": "application/json",
       },
@@ -36,7 +38,7 @@ const Login: NextPage = ({ d }) => {
       .then((data) => {
         if (data["response"] !== undefined) {
           console.log("Logged In:", data);
-          // router.push("/");
+          router.push("/");
         } else {
           console.log("Permission Denied:", data);
         }

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -36,7 +36,7 @@ const Login: NextPage = ({ d }) => {
       .then((data) => {
         if (data["response"] !== undefined) {
           console.log("Logged In:", data);
-          router.push("/");
+          // router.push("/");
         } else {
           console.log("Permission Denied:", data);
         }


### PR DESCRIPTION
A simple endpoint to get the user profile. This PR mainly for the demo today. Other endpoints will be added later (return user role with the profile request, Add section/task, and get Sections and tasks, assign users to group (We assume that groups are made before hand by the DB manager as well as the users -for now- since the main point of this project is "management during the semester", and we need to make that as a priority goal.)).

To activate the `/users/get/profile` endpoint, please login (Don't forget to edit the `mode` and `credentials` in your fetch request so cookies can be send over to our backend). 