### PR TITLE
Move testcases to yaml conversion and add filename to submissions

### DIFF
--- a/cleanDB/scripts/clean_db.sql
+++ b/cleanDB/scripts/clean_db.sql
@@ -155,6 +155,7 @@ CREATE TABLE public.grades (
     gradeID     INT             DEFAULT nextval('gradeSeq'),
     userID      INT             REFERENCES  users(userID)           NOT NULL,
     taskID      INT             REFERENCES  tasks(taskID)           NOT NULL,
+    filename    VARCHAR(50),
     submission  VARCHAR(5000)   DEFAULT NULL, -- 5KB Storage of text. 
     grade       INT             DEFAULT NULL,
     PRIMARY KEY (gradeID)
@@ -221,21 +222,18 @@ addInt a b = a + b
 subInt :: Int Int -> Int
 subInt a b = a - b
 
-', 
+',
 '
-test_questions:
-\t- q1:
-\t\t\tfunction_name: addInt
-\t\t\ttest_cases:
-\t\t\t\t- 1 2
-\t\t\t\t- 5 13
-\t\t\t\t- 12 99
-\t- q2:
-\t\t\tfunction_name: subInt
-\t\t\ttest_cases:
-\t\t\t\t- 3 4
-\t\t\t\t- 3 2
-\t\t\t\t- 23 32
+[
+    {
+        "functionname": "addInt", 
+        "parameters": ["1 2", "5 13", "12 99"]
+    },
+    {
+        "functionname": "subInt", 
+        "parameters": ["3 4", "3 2", "23 32"]
+    }
+]
 '
 , 1);
 INSERT INTO tasks (taskName, sectionID, description, solution, max) VALUES ('Progress Task 1', 2, 'desc', 'module teacher
@@ -272,19 +270,16 @@ subInt a b = a - b
 
 ', 
 '
-test_questions:
-\t- q1:
-\t\t\tfunction_name: addInt
-\t\t\ttest_cases:
-\t\t\t\t- 1 2
-\t\t\t\t- 5 13
-\t\t\t\t- 12 99
-\t- q2:
-\t\t\tfunction_name: subInt
-\t\t\ttest_cases:
-\t\t\t\t- 3 4
-\t\t\t\t- 3 2
-\t\t\t\t- 23 32
+[
+    {
+        "functionname": "addInt", 
+        "parameters": ["1 2", "5 13", "12 99"]
+    },
+    {
+        "functionname": "subInt", 
+        "parameters": ["3 4", "3 2", "23 32"]
+    }
+]
 '
 , 3);
 INSERT INTO tasks (taskName, sectionID, description, solution, max) VALUES ('Endterm', 5, 'desc', 'module teacher
@@ -300,7 +295,7 @@ subInt a b = a - b
 ', 4);
 
 ---------------------- Students files Dumb data
-INSERT INTO grades (userID, taskID, submission, grade) VALUES (1, 1, 'import StdEnv 
+INSERT INTO grades (userID, taskID, filename, submission, grade) VALUES (1, 1, 'midterm (2).icl','import StdEnv 
 
 addInt :: Int Int -> Int
 addInt a b = a + b

--- a/scripts/CorrectTest.py
+++ b/scripts/CorrectTest.py
@@ -76,9 +76,9 @@ class CorrectTest:
             file_path)
         pass_str = f"Compiling {file_name_without_icl}\nGenerating code for {file_name_without_icl}\nLinking {file_name_without_icl}"
         for index, question in enumerate(self.test_questions):
-            function_name = question[f'q{index + 1}']["function_name"]
+            function_name = question["function_name"]
             function_tests = {}
-            for test in question[f'q{index + 1}']["test_cases"]:
+            for test in question["test_cases"]:
                 with open(file_path, 'a') as write_obj:
                     write_obj.write(f'Start = {function_name} {test}\n')
 


### PR DESCRIPTION
Instead of storing the yaml format of testcases in the database, we now store the stringified json format as is given in the request. The conversion happens only for the grading script.

Also, now we save the filename of submissions in the _grades_ table of our database. The filename is returned in the tasks submission get endpoint alongside the actual student's submission when the submission parameter is set to true.

Closes #82 #83 