### PR TITLE
Assign to Groups Through Neptun ID and Group Names

### DIFF
--- a/backend/routes/groups.js
+++ b/backend/routes/groups.js
@@ -80,7 +80,7 @@ router.get("/", isAuth, protector(["admin", "demonstrator"]), async (req, res, n
     }
 
     /* If userID not found, get its id from querying the database... */
-    let uid;
+    let uid = req.body.userID;
     if(!req.body.userID && req.body.neptun){
         const result = await selectFromTable('users', {neptun: req.body.neptun});
         if (result.error) 
@@ -91,7 +91,7 @@ router.get("/", isAuth, protector(["admin", "demonstrator"]), async (req, res, n
     }
 
     /* Get Group ID if groupName exists */
-    let gid;
+    let gid = req.body.groupID;
     if(!req.body.groupID && req.body.groupName){
         const result = await selectFromTable('groups', {groupname: req.body.groupName});
         if (result.error) 
@@ -129,7 +129,7 @@ router.delete("/unassign", isAuth, protector(["admin"]), async (req, res, next) 
     }
 
     /* If userID not found, get its id from querying the database... */
-    let uid;
+    let uid = req.body.userID;
     if(!req.body.userID && req.body.neptun){
         const result = await selectFromTable('users', {neptun: req.body.neptun});
         if (result.error) 
@@ -140,7 +140,7 @@ router.delete("/unassign", isAuth, protector(["admin"]), async (req, res, next) 
     }
 
     /* Get Group ID if groupName exists */
-    let gid;
+    let gid = req.body.groupID;
     if(!req.body.groupID && req.body.groupName){
         const result = await selectFromTable('groups', {groupname: req.body.groupName});
         if (result.error) 

--- a/backend/routes/groups.js
+++ b/backend/routes/groups.js
@@ -6,12 +6,15 @@ const { selectFromTable, insertIntoTable, deleteFromTable, updateTable } = requi
 const { isAuth, protector, keycloak , getSelfData} = require('../utils/keycloak_utils');
 
 
+
 /**
  * Get groups
  */
 router.get("/", isAuth, protector(["admin", "demonstrator"]), async (req, res, next) => {
     if(!process.env.DISABLE_AUTHENTICATION && !process.env.DISABLE_AUTHORIZATION){
         const userData = await getSelfData(req,res);
+        
+        /* Get only groups that are assigned to the demonstrator */
         if(userData.user.roles.indexOf("demonstrator") >= 0){
             /* Get user id from database */
             let result = await selectFromTable("users", {username : userData.user.username});
@@ -42,35 +45,120 @@ router.get("/", isAuth, protector(["admin", "demonstrator"]), async (req, res, n
 });
 
 
+
 /**
- * Creates a new group
+ * Creates a new group .. Only admins can create new groups
  * req.body: {groupname, timetable?}
  */
- router.post("/create", isAuth, protector(["admin", "demonstrator"]), async (req, res, next) => {
+ router.post("/create", isAuth, protector(["admin"]), async (req, res, next) => {
     const result = await insertIntoTable('groups', req.body);
     if (result.error) 
         return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
     return res.status(200).send(JSON.stringify({message: "Group successfully created"}));
 });
 
+
+
 /**
  * Assign a user to a group. Only admins can do this...
+ * 
+ * The endpoint deduce the user by its userID, if userID is not found in the request, then its neptun is prioritized.
+ * Therefore, provide either the userID or the Neptun. Same logic goes to the groups
+ * req.body: {
+ *  userID : <Integer>,
+ *  neptun: <Text>,
+ *  groupID : <Integer>,
+ *  groupName : <Text> 
+ * }
  */
  router.put("/assign", isAuth, protector(["admin"]), async (req, res, next) => {
-    const result = await insertIntoTable('user_to_group', req.body);
-    if (result.error) 
-        return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
-    return res.status(200).send(JSON.stringify({message: "User successfully assigned to group"}));
+    if(req.body.userID && req.body.groupID){
+        const result = await insertIntoTable('user_to_group', {userID: req.body.userID, groupID: req.body.groupID});
+        if (result.error) 
+            return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
+        return res.status(200).send(JSON.stringify({message: "User successfully assigned to group"}));
+    }
+
+    /* If userID not found, get its id from querying the database... */
+    let uid;
+    if(!req.body.userID && req.body.neptun){
+        const result = await selectFromTable('users', {neptun: req.body.neptun});
+        if (result.error) 
+            return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
+        if (result.result.rows.length == 0)
+            return res.status(404).send(JSON.stringify({message: "User is not Found!"}));
+        uid = result.result.rows[0].userid;
+    }
+
+    /* Get Group ID if groupName exists */
+    let gid;
+    if(!req.body.groupID && req.body.groupName){
+        const result = await selectFromTable('groups', {groupname: req.body.groupName});
+        if (result.error) 
+            return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
+        if (result.result.rows.length == 0)
+            return res.status(404).send(JSON.stringify({message: "Group is not Found!"}));
+        gid = result.result.rows[0].groupid;
+    }
+
+    /* Assign users to group. */
+    if(gid && uid){
+        const result = await insertIntoTable('user_to_group', {userID: uid, groupID: gid});
+        if (result.error) 
+            return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
+        return res.status(200).send(JSON.stringify({message: "User successfully assigned to group"}));
+    }
+    return next("Error in assigning user to group");
+    
 });
+
+
 
 /**
  * Unassign a user from group. Only admins can do this...
+ * 
+ * Works with the same logic as the assign users to group. Please insert the userID or neptun and the group 
+ * to unassign from
  */
 router.delete("/unassign", isAuth, protector(["admin"]), async (req, res, next) => {
-    const result = await deleteFromTable('user_to_group', req.body);
-    if (result.error) 
-        return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
-    return res.status(200).send(JSON.stringify({message: "User successfully unassigned from group"}));
+    if(req.body.userID && req.body.groupID){
+        const result = await deleteFromTable('user_to_group', {userID: req.body.userID, groupID: req.body.groupID});
+        if (result.error) 
+            return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
+        return res.status(200).send(JSON.stringify({message: "User successfully assigned to group"}));
+    }
+
+    /* If userID not found, get its id from querying the database... */
+    let uid;
+    if(!req.body.userID && req.body.neptun){
+        const result = await selectFromTable('users', {neptun: req.body.neptun});
+        if (result.error) 
+            return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
+        if (result.result.rows.length == 0)
+            return res.status(404).send(JSON.stringify({message: "User is not Found!"}));
+        uid = result.result.rows[0].userid;
+    }
+
+    /* Get Group ID if groupName exists */
+    let gid;
+    if(!req.body.groupID && req.body.groupName){
+        const result = await selectFromTable('groups', {groupname: req.body.groupName});
+        if (result.error) 
+            return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
+        if (result.result.rows.length == 0)
+            return res.status(404).send(JSON.stringify({message: "Group is not Found!"}));
+        gid = result.result.rows[0].groupid;
+    }
+
+    /* Assign users to group. */
+    if(gid && uid){
+        const result = await deleteFromTable('user_to_group', {userID: uid, groupID: gid});
+        if (result.error) 
+            return res.status(500).send(JSON.stringify({message: "Transaction Failed"}));
+        return res.status(200).send(JSON.stringify({message: "User successfully unassigned to group"}));
+    }
+    return next("Error in unassigning user to group");
+
 });
 
 

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -4,7 +4,7 @@
 const router = require('express-promise-router')();     // Used to handle async request. Will be useful in the future to dodge the pyramid of doom
 const keycloak = require('../utils/keycloak_utils').keycloak;
 const { isAuth, getSelfData, isUnauth, getAllUsersData, createUsers, protector, updateUserRole, deleteUser } = require('../utils/keycloak_utils');
-const { selectFromTable, insertIntoTable, deleteFromTable } = require('../utils/database_utils');
+const { selectFromTable, insertIntoTable, deleteFromTable, execQuery } = require('../utils/database_utils');
 const log = require('../utils/logger_utils').log;
 
 


### PR DESCRIPTION
Enhanced the assign to group endpoint `groups/assign`. The new endpoint allows the client to provide any of the combinations that specify a user and a group. For instance: user can be defined by its userID or neptun. E.G:

`/groups/assign` [PUT] 
body:
`
userID || neptun,
groupID || groupName
`

if both entries that define a single entity are given (userID and neptun), userID is prioritized. The same logic applies to groups.

NOTE: The same logic applies for `groups/unassign` endpoint as well.

Furthermore, fixed a bug in `users/` [GET] endpoint.