### PR TITLE
Fix: Task Creation

### DIFF
--- a/backend/routes/sections.js
+++ b/backend/routes/sections.js
@@ -32,14 +32,18 @@ router.get("/", isAuth, async (req, res, next) => {
 
 /**
  * Creates a new section to a group.
- * req.body: {sectionid, groupid}
+ * req.body: {sectionName, groupid}
  */
 router.post(
   "/create",
   isAuth,
   protector(["admin", "demonstrator"]),
   async (req, res, next) => {
-    const result = await insertIntoTable("sections", req.body);
+    const params = {};
+    params.sectionName = req.body.sectionName || req.body.sectionname;
+    params.groupID = req.body.groupid || req.body.groupID;
+
+    const result = await insertIntoTable("sections", params);
     if (result.error)
       return res
         .status(500)

--- a/backend/routes/tasks.js
+++ b/backend/routes/tasks.js
@@ -115,47 +115,33 @@ router.get("/:taskID/submissions", isAuth, async (req, res, next) => {
  * The solution and description can be given through the req.body, or passed by a multipart/form_data protocol.
  *
  */
-router.post(
-  "/create",
-  fileUpload({ createParentPath: true }),
-  isAuth,
-  protector(["admin", "demonstrator"]),
-  async (req, res, next) => {
-    /* Check if the the incoming data are complete */
-    const fileNotInForm =
-      !req.files || !req.files.solution || !req.files.description;
-    const fileNotInBody =
-      !req.body || !req.body.solution || !req.body.description;
-    const incompleteFile = fileNotInForm && fileNotInBody;
-    const incompleteBody = !req.body || !req.body.name || !req.body.sectionid;
-    if (incompleteFile || incompleteBody)
-      return res.status(400).send({ message: "Missing input parameters!" });
+router.post("/create", fileUpload({ createParentPath: true }), isAuth, protector(["admin", "demonstrator"]), async (req, res, next) => {
+  /* Check if the the incoming data are complete */
+  const dataNotInForm = !req.files || !req.files.solution || !req.files.description || !req.files.name || !req.files.sectionid;
+  const dataNotInBody = !req.body || !req.body.solution || !req.body.description || !req.body.name || !req.body.sectionid;
+  if (dataNotInForm && dataNotInBody)
+    return res.status(400).send({ message: "Missing input parameters!" });
 
-    const solution =
-      req.files?.solution.data.toString("utf8") || req.body.solution;
-    const description =
-      req.files?.description.data.toString("utf8") || req.body.description;
+  const ts = new Date();
 
-    const ts = new Date();
-    /* Inserting the task into the table */
-    const params = {
-      sectionid: req.body.sectionid,
-      max: req.body.maxGrade,
-      taskname: req.body.name,
-      expiryDate:
-        req.body.dueDate ||
-        `${ts.getFullYear()}-${ts.getMonth()}-${ts.getDay()}`,
-      expiryTime:
-        req.body.dueTime ||
-        `${ts.getHours()}:${ts.getMinutes()}:${ts.getSeconds()}`,
-      solution: solution.replace(/^.*module.*$/g, "").replace(/\'/g, "''"),
-      description: description.replace(/\'/g, "''"),
-      testquestions: req.body.testcases,
-    };
-    const result = await insertIntoTable("tasks", params);
-    if (result.error)
-      return res.status(500).send({ message: "Failed to insert task" });
-    return res.status(200).send({ message: "Task created successfully!" });
+  const solution = req.files?.solution.data.toString("utf8") || req.body.solution;
+  const description = req.files?.description.data.toString("utf8") || req.body.description;
+  
+  /* Inserting the data into the table */
+  const params;
+  params.sectionid = req.files?.sectionid || req.body?.sectionid;
+  params.max = req.files?.maxGrade ||  req.body?.maxGrade;
+  params.taskname = req.files?.name || req.body?.name;
+  params.expiryDate = req.files?.dueDate || req.body?.dueDate || `${ts.getFullYear()}-${ts.getMonth()}-${ts.getDay()}`;
+  params.expiryTime = req.files?.dueTime || req.body?.dueTime || `${ts.getHours()}:${ts.getMinutes()}:${ts.getSeconds()}`;
+  params.testquestions = req.files?.testcases || req.body.testcases;
+  params.solution = solution.replace(/^.*module.*$/g, "").replace(/\'/g, "''");
+  params.description = description.replace(/\'/g, "''");
+
+  const result = await insertIntoTable("tasks", params);
+  if (result.error)
+    return res.status(500).send({ message: "Failed to insert task" });
+  return res.status(200).send({ message: "Task created successfully!" });
   }
 );
 

--- a/backend/routes/tasks.js
+++ b/backend/routes/tasks.js
@@ -134,7 +134,7 @@ router.post("/create", fileUpload({ createParentPath: true }), isAuth, protector
   params.taskname = req.files?.name || req.body?.name;
   params.expiryDate = req.files?.dueDate || req.body?.dueDate || `${ts.getFullYear()}-${ts.getMonth()}-${ts.getDay()}`;
   params.expiryTime = req.files?.dueTime || req.body?.dueTime || `${ts.getHours()}:${ts.getMinutes()}:${ts.getSeconds()}`;
-  params.testquestions = req.files?.testcases || req.body.testcases;
+  params.testquestions = req.files?.testcases || req.body.testcases || "";
   params.solution = solution.replace(/^.*module.*$/g, "").replace(/\'/g, "''");
   params.description = description.replace(/\'/g, "''");
 


### PR DESCRIPTION
Task creation endpoint have been edited to embrace more flexibility regarding where the data are stored. They can be either in the req.files (Form) or req.body (data). Anywhere they are, the endpoint captures the data and creates the task accordingly.